### PR TITLE
Validate the entities are created in monitoring namespace

### DIFF
--- a/roles/openshift_prometheus_operator/deploy.sh
+++ b/roles/openshift_prometheus_operator/deploy.sh
@@ -3,6 +3,7 @@
 
 #oc login -u system:admin
 oc new-project monitoring
+oc project monitoring
 
 oc apply -f files/manifests/prometheus-operator
 


### PR DESCRIPTION
If project 'monitoring' exists, the 'new-project' command will fail, and all the objects will be created under 'default' namespace.
the aditional 'oc project' command makes sure that the active project is 'monitoring'