### PR TITLE
Don't add cluter-reader permission

### DIFF
--- a/roles/openshift_prometheus_operator/deploy.sh
+++ b/roles/openshift_prometheus_operator/deploy.sh
@@ -6,8 +6,6 @@ oc new-project monitoring
 
 oc apply -f files/manifests/prometheus-operator
 
-oc adm policy add-cluster-role-to-user cluster-reader -z prometheus-operator
-
 printf "Waiting for Operator to register custom resource definitions..."
 until oc get customresourcedefinitions servicemonitors.monitoring.coreos.com > /dev/null 2>&1; do sleep 1; printf "."; done
 echo "Done!"


### PR DESCRIPTION
This is not needed anymore after the changes made in https://github.com/ironcladlou/openshift-ansible/commit/a2d33f6d40988a3949c6221cac3fdbc9309a4b64