### PR TITLE
Connect alert manager to auto-heal

### DIFF
--- a/roles/openshift_prometheus_operator/files/assets/alertmanager/alertmanager.yaml
+++ b/roles/openshift_prometheus_operator/files/assets/alertmanager/alertmanager.yaml
@@ -12,3 +12,6 @@ route:
     receiver: 'null'
 receivers:
 - name: 'null'
+- name: autoheal
+  webhook_configs:
+  - url: http://autoheal.openshift-autoheal.svc.cluster.local:9099


### PR DESCRIPTION
This patch modifies the Prometheus alert manager configuration file so
that it sends alert notifications to the auto-heal service.