### PR TITLE
Add demo alerting rules and routes

### DIFF
--- a/roles/openshift_prometheus_operator/files/assets/alertmanager/alertmanager.yaml
+++ b/roles/openshift_prometheus_operator/files/assets/alertmanager/alertmanager.yaml
@@ -11,7 +11,12 @@ route:
       alertname: DeadMansSwitch
     receiver: 'null'
   - match:
-      alertname: K8SControllerManagerDown
+      alertname: OpenShiftApiserverDown
+      severity: critical
+    receiver: 'null'
+  - match:
+      alertname: OpenShiftApiserverDown
+      severity: page
     receiver: 'openshift-pagerduty'
 receivers:
 - name: 'null'

--- a/roles/openshift_prometheus_operator/files/assets/prometheus/rules/demo.rules.yaml
+++ b/roles/openshift_prometheus_operator/files/assets/prometheus/rules/demo.rules.yaml
@@ -1,0 +1,19 @@
+groups:
+- name: demo.rules
+  rules:
+  - alert: OpenShiftApiserverDown
+    expr: absent(up{job="apiserver"} == 1)
+    for: 30s
+    labels:
+      severity: critical
+    annotations:
+      description: No API servers are reachable or all have disappeared from service
+        discovery
+  - alert: OpenShiftApiserverDown
+    expr: absent(up{job="apiserver"} == 1)
+    for: 1m
+    labels:
+      severity: page
+    annotations:
+      description: No API servers are reachable or all have disappeared from service
+        discovery


### PR DESCRIPTION
Add a simple set of demo alerting rules and routes to test PagerDuty
and auto-heal integration.