### PR TITLE
Fix auto-heal alert name

### DIFF
--- a/roles/openshift_autoheal/defaults/main.yml
+++ b/roles/openshift_autoheal/defaults/main.yml
@@ -11,4 +11,4 @@ openshift_autoheal_service_port: 9099
 
 # The regular expression that alerts (the `alertname` label) should
 # match in order to be automatically handled by the auto heal service.
-openshift_autoheal_alert_pattern: "K8SApiserverDown"
+openshift_autoheal_alert_pattern: "OpenShiftApiserverDown"


### PR DESCRIPTION
This patch adapts the auto-heal script to the alert name that was
introduced in the following pull request:

  Add demo alerting rules and routes
  https://github.com/ironcladlou/openshift-ansible/pull/21