### PR TITLE
Add auto-heal playbook to start API server

### DIFF
--- a/playbooks/openshift-autoheal/start_api_server.yml
+++ b/playbooks/openshift-autoheal/start_api_server.yml
@@ -1,0 +1,7 @@
+---
+- name: Start the API server
+  hosts: all
+  tasks:
+  - systemd:
+      name: origin-master-api
+      state: started


### PR DESCRIPTION
This patch adds a simple playbook that will be used by the auto-heal
demo to start the API server.