### PR TITLE
Check for master node before starting API server

### DIFF
--- a/playbooks/openshift-autoheal/start_api_server.yml
+++ b/playbooks/openshift-autoheal/start_api_server.yml
@@ -1,7 +1,15 @@
 ---
-- name: Start the API server
+- name: Start the API servers
   hosts: all
   tasks:
-  - systemd:
-      name: origin-master-api
+
+  - name: Check if this is a master node
+    stat:
+      path: /usr/lib/systemd/system/origin-master-api.service
+    register: master_service
+
+  - restart: Start the API servers on master nodes
+    systemd:
       state: started
+      name: origin-master-api
+    when: master_service.stat.exists


### PR DESCRIPTION
Currently the auto-heal playbook that is used to start the API server
does so without first checking if the node is a master. This means that
the execution will be marked as failure for non master nodes, and those
nodes will also be marked as failed (inside the AWX database). The ideal
way to solve that would be to define a `masters` group in the inventory,
and run the playbook ony for those nodes. But currently this isn't
feasible because there is no easy way to automatically create an AWX
group and add hosts to it. To work around that this patch modifies the
playbook so that it explicitly checks if the node is a master before
trying to start the service.