### PR TITLE
Send API server down alert to autoheal service

### DIFF
--- a/roles/openshift_prometheus_operator/files/assets/alertmanager/alertmanager.yaml
+++ b/roles/openshift_prometheus_operator/files/assets/alertmanager/alertmanager.yaml
@@ -13,7 +13,7 @@ route:
   - match:
       alertname: OpenShiftApiserverDown
       severity: critical
-    receiver: 'null'
+    receiver: autoheal
   - match:
       alertname: OpenShiftApiserverDown
       severity: page


### PR DESCRIPTION
Currently the alert manager routes are configured in such a way that the
alert used for the demo isn't sent to the auto-heal service. This patch
fixes that.