### PR TITLE
Route by severity

### DIFF
--- a/roles/openshift_prometheus_operator/files/assets/alertmanager/alertmanager.yaml
+++ b/roles/openshift_prometheus_operator/files/assets/alertmanager/alertmanager.yaml
@@ -11,11 +11,9 @@ route:
       alertname: DeadMansSwitch
     receiver: 'null'
   - match:
-      alertname: OpenShiftApiserverDown
       severity: critical
     receiver: autoheal
   - match:
-      alertname: OpenShiftApiserverDown
       severity: page
     receiver: 'openshift-pagerduty'
 receivers:


### PR DESCRIPTION
An alert route design suggestion. Pass all alerts to receivers by severity:
critical -> autoheal
page -> pagerduty

cc @ironcladlou @elad661 @jhernand