### PR TITLE
Configure alertmanager in the cluster-monitoring-operator role

### DIFF
--- a/roles/openshift_cluster_monitoring_operator/README.md
+++ b/roles/openshift_cluster_monitoring_operator/README.md
@@ -8,9 +8,10 @@ Ansible 2.4
 
 # Role Variables
 
-| Name                                      | Default                |                  |
-|-------------------------------------------|------------------------|------------------|
-|                                           |                        |                  |
+| Name                                          | Default                |                  |
+|-----------------------------------------------|------------------------|------------------|
+| prometheus_operator_pagerduty_service_key     |                        |                  |
+| openshift_cluster_monitoring_enable_pagerduty |  false                 |                  |
 
 # Dependencies
 

--- a/roles/openshift_cluster_monitoring_operator/defaults/main.yaml
+++ b/roles/openshift_cluster_monitoring_operator/defaults/main.yaml
@@ -1,1 +1,5 @@
 ---
+prometheus_operator_alertmanager_global:
+  resolve_timeout: 5m
+prometheus_operator_pagerduty_service_key: null
+openshift_cluster_monitoring_enable_pagerduty: false

--- a/roles/openshift_cluster_monitoring_operator/files/alertmanager.yaml
+++ b/roles/openshift_cluster_monitoring_operator/files/alertmanager.yaml
@@ -1,0 +1,25 @@
+global:
+  resolve_timeout: 5m
+route:
+  group_by: ['job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: 'null'
+  routes:
+  - match:
+      alertname: DeadMansSwitch
+    receiver: 'null'
+  - match:
+      severity: critical
+    receiver: autoheal
+  - match:
+      severity: page
+    receiver: 'openshift-pagerduty'
+receivers:
+- name: 'null'
+- name: autoheal
+  webhook_configs:
+  - url: http://autoheal.openshift-monitoring.svc.cluster.local:9099
+- name: 'openshift-pagerduty'
+

--- a/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
+++ b/roles/openshift_cluster_monitoring_operator/tasks/install.yaml
@@ -4,12 +4,12 @@
   register: mktemp
   changed_when: False
 
-- set_fact:
-    # TODO: remove
-    openshift_client_binary: /usr/bin/oc
-    openshift:
-      common:
-        config_base: /etc/origin
+# - set_fact:
+#    # TODO: remove
+#     openshift_client_binary: /usr/bin/oc
+#     openshift:
+#       common:
+#         config_base: /etc/origin
 
 - name: Copy files to temp directory
   copy:
@@ -18,6 +18,7 @@
   with_items:
   - app-version.yaml
   - app-version-openshift-monitoring.yaml
+  - alertmanager.yaml
   - cluster-monitoring-operator.yaml
   - monitoring-config.yaml
   - project.yaml
@@ -40,6 +41,43 @@
     {{ openshift_client_binary }} adm policy add-cluster-role-to-user cluster-admin -z default
     --config={{ mktemp.stdout }}/admin.kubeconfig
     -n openshift-monitoring
+
+- name: Update alertmanager config
+  yedit:
+    src: "{{ mktemp.stdout }}/alertmanager.yaml"
+    edits:
+    - key: global
+      value: "{{ prometheus_operator_alertmanager_global }}"
+    separator: '#'
+    state: present
+    debug: true
+
+- name: Configure PagerDuty Receiver
+  yedit:
+    src: "{{ mktemp.stdout }}/alertmanager.yaml"
+    edits:
+    - key: receivers
+      value:
+      - name: 'null'
+      - name: autoheal
+        webhook_configs:
+        - url: http://autoheal.openshift-monitoring.svc.cluster.local:9099
+      - name: 'openshift-pagerduty'
+        pagerduty_configs:
+        - service_key: "{{ prometheus_operator_pagerduty_service_key }}"
+    separator: '#'
+    state: present
+    debug: true
+  when: openshift_cluster_monitoring_enable_pagerduty
+
+- name: Create alertmanager secret config
+  oc_secret:
+    name: alertmanager-main
+    namespace: openshift-monitoring
+    state: present
+    files:
+    - name: alertmanager.yaml
+      path: "{{ mktemp.stdout }}/alertmanager.yaml"
 
 - name: Apply the cluster monitoring operator manifests
   command: >


### PR DESCRIPTION
Just like we did in the Prometheus Operator role.

Also made pagerduty optional - if the key is configured as "null" alertmanager refuses to start, claiming the config is invalid. Completely omitting pagerduty related stuff when it's not enabled fixes this issue.